### PR TITLE
[#13] 프로젝트 리세팅

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+generate:
+	tuist generate
+	arch -x86_64 pod install

--- a/Project.swift
+++ b/Project.swift
@@ -20,9 +20,6 @@ let project = Project(
                     script: "${PODS_ROOT}/SwiftLint/swiftlint",
                     name: "SwiftLint"
                 )
-            ],
-            dependencies: [
-                .cocoapods(path: ".")
             ]
         )
     ]


### PR DESCRIPTION
tuist 2.0.0 에서 DEPRECATED된 dependencies의 .cocoapods()을 제거하고 makefile을 만들어 cocoapods를 관리하도록 수정하였습니다.

프로젝트 생성 명령어는 아래와 같습니다.
```
   $ make generate
```